### PR TITLE
Telephony: Allow customizing display name for different phone

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -76,6 +76,22 @@
     <string name="time_formate_am">AM</string>
     <string name="time_formate_pm">PM</string>
 
+    <!-- Mobile network settings, preferred network modes -->
+    <string name="network_wcdma_only">@string/network_3G</string>
+    <string name="network_gsm_umts">@string/network_3G</string>
+    <string name="network_wcdma_pref">@string/network_3G</string>
+    <string name="network_gsm_only">@string/network_2G</string>
+    <string name="network_lte_gsm_wcdma">@string/network_lte</string>
+    <string name="network_lte_cdma">@string/network_lte</string>
+    <string name="network_lte_only">@string/network_lte</string>
+    <string name="network_lte_cdma_and_evdo">@string/network_lte</string>
+    <string name="network_cdma">@string/network_3G</string>
+    <string name="network_evdo_no_cdma">@string/network_3G</string>
+    <string name="network_3g_global">@string/network_3G</string>
+    <string name="network_cdma_no_evdo">@string/network_1x</string>
+    <string name="network_lte_cdma_evdo_gsm_wcdma">@string/network_global</string>
+    <string name="network_4G_only">@string/network_4G</string>
+
     <!-- Mobile network settings, summary for preferred network mode Global[CHAR LIMIT=100] -->
     <string name="preferred_network_mode_global_summary_cm">Preferred network mode: Global (CDMA/EvDo/LTE/GSM/WCDMA)</string>
 

--- a/src/com/android/phone/MobileNetworkSettings.java
+++ b/src/com/android/phone/MobileNetworkSettings.java
@@ -964,6 +964,12 @@ public class MobileNetworkSettings extends PreferenceActivity
                     case Phone.NT_MODE_LTE_TDSCDMA_GSM_WCDMA:
                     case Phone.NT_MODE_TDSCDMA_CDMA_EVDO_GSM_WCDMA:
                     case Phone.NT_MODE_LTE_TDSCDMA_CDMA_EVDO_GSM_WCDMA:
+                    case Phone.NT_MODE_WCDMA_ONLY:
+                    case Phone.NT_MODE_GSM_UMTS:
+                    case Phone.NT_MODE_EVDO_NO_CDMA:
+                    case Phone.NT_MODE_GLOBAL:
+                    case Phone.NT_MODE_LTE_ONLY:
+                    case Phone.NT_MODE_LTE_WCDMA:
                         // This is one of the modes we recognize
                         modemNetworkMode = buttonNetworkMode;
                         break;
@@ -1188,61 +1194,56 @@ public class MobileNetworkSettings extends PreferenceActivity
                 mButtonEnabledNetworks.setSummary(R.string.network_3G);
                 break;
             case Phone.NT_MODE_WCDMA_ONLY:
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_WCDMA_ONLY));
+                mButtonEnabledNetworks.setSummary(R.string.network_wcdma_only);
+                break;
             case Phone.NT_MODE_GSM_UMTS:
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_GSM_UMTS));
+                mButtonEnabledNetworks.setSummary(R.string.network_gsm_umts);
+                break;
             case Phone.NT_MODE_WCDMA_PREF:
-                if (!mIsGlobalCdma) {
-                    mButtonEnabledNetworks.setValue(
-                            Integer.toString(Phone.NT_MODE_WCDMA_PREF));
-                    mButtonEnabledNetworks.setSummary(R.string.network_3G);
-                } else {
-                    mButtonEnabledNetworks.setValue(
-                            Integer.toString(Phone.NT_MODE_LTE_CDMA_EVDO_GSM_WCDMA));
-                    mButtonEnabledNetworks.setSummary(R.string.network_global);
-                }
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_WCDMA_PREF));
+                mButtonEnabledNetworks.setSummary(R.string.network_wcdma_pref);
                 break;
             case Phone.NT_MODE_GSM_ONLY:
-                if (!mIsGlobalCdma) {
-                    mButtonEnabledNetworks.setValue(
-                            Integer.toString(Phone.NT_MODE_GSM_ONLY));
-                    mButtonEnabledNetworks.setSummary(R.string.network_2G);
-                } else {
-                    mButtonEnabledNetworks.setValue(
-                            Integer.toString(Phone.NT_MODE_LTE_CDMA_EVDO_GSM_WCDMA));
-                    mButtonEnabledNetworks.setSummary(R.string.network_global);
-                }
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_GSM_ONLY));
+                mButtonEnabledNetworks.setSummary(R.string.network_gsm_only);
                 break;
             case Phone.NT_MODE_LTE_GSM_WCDMA:
                 if (isWorldMode()) {
-                    mButtonEnabledNetworks.setSummary(
-                            R.string.preferred_network_mode_lte_gsm_umts_summary);
                     controlCdmaOptions(false);
                     controlGsmOptions(true);
-                    break;
                 }
-            case Phone.NT_MODE_LTE_ONLY:
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_LTE_GSM_WCDMA));
+                mButtonEnabledNetworks.setSummary((mShow4GForLTE == true)
+                        ? R.string.network_4G : R.string.network_lte_gsm_wcdma);
+                break;
             case Phone.NT_MODE_LTE_WCDMA:
-                if (!mIsGlobalCdma) {
-                    mButtonEnabledNetworks.setValue(
-                            Integer.toString(Phone.NT_MODE_LTE_GSM_WCDMA));
-                    mButtonEnabledNetworks.setSummary((mShow4GForLTE == true)
-                            ? R.string.network_4G : R.string.network_lte);
-                } else {
-                    mButtonEnabledNetworks.setValue(
-                            Integer.toString(Phone.NT_MODE_LTE_CDMA_EVDO_GSM_WCDMA));
-                    mButtonEnabledNetworks.setSummary(R.string.network_global);
-                }
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_LTE_WCDMA));
+                mButtonEnabledNetworks.setSummary((mShow4GForLTE == true)
+                        ? R.string.network_4G : R.string.network_lte_cdma);
+                break;
+            case Phone.NT_MODE_LTE_ONLY:
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_LTE_ONLY));
+                mButtonEnabledNetworks.setSummary((mShow4GForLTE == true)
+                        ? R.string.network_4G_only : R.string.network_lte_only);
                 break;
             case Phone.NT_MODE_LTE_CDMA_AND_EVDO:
                 if (isWorldMode()) {
-                    mButtonEnabledNetworks.setSummary(
-                            R.string.preferred_network_mode_lte_cdma_summary);
                     controlCdmaOptions(true);
                     controlGsmOptions(false);
-                } else {
-                    mButtonEnabledNetworks.setValue(
-                            Integer.toString(Phone.NT_MODE_LTE_CDMA_AND_EVDO));
-                    mButtonEnabledNetworks.setSummary(R.string.network_lte);
                 }
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_LTE_CDMA_AND_EVDO));
+                mButtonEnabledNetworks.setSummary((mShow4GForLTE == true)
+                        ? R.string.network_4G : R.string.network_lte_cdma_and_evdo);
                 break;
             case Phone.NT_MODE_TDSCDMA_CDMA_EVDO_GSM_WCDMA:
                 mButtonEnabledNetworks.setValue(
@@ -1250,16 +1251,24 @@ public class MobileNetworkSettings extends PreferenceActivity
                 mButtonEnabledNetworks.setSummary(R.string.network_3G);
                 break;
             case Phone.NT_MODE_CDMA:
-            case Phone.NT_MODE_EVDO_NO_CDMA:
-            case Phone.NT_MODE_GLOBAL:
                 mButtonEnabledNetworks.setValue(
                         Integer.toString(Phone.NT_MODE_CDMA));
-                mButtonEnabledNetworks.setSummary(R.string.network_3G);
+                mButtonEnabledNetworks.setSummary(R.string.network_cdma);
+                break;
+            case Phone.NT_MODE_EVDO_NO_CDMA:
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_EVDO_NO_CDMA));
+                mButtonEnabledNetworks.setSummary(R.string.network_evdo_no_cdma);
+                break;
+            case Phone.NT_MODE_GLOBAL:
+                mButtonEnabledNetworks.setValue(
+                        Integer.toString(Phone.NT_MODE_GLOBAL));
+                mButtonEnabledNetworks.setSummary(R.string.network_3g_global);
                 break;
             case Phone.NT_MODE_CDMA_NO_EVDO:
                 mButtonEnabledNetworks.setValue(
                         Integer.toString(Phone.NT_MODE_CDMA_NO_EVDO));
-                mButtonEnabledNetworks.setSummary(R.string.network_1x);
+                mButtonEnabledNetworks.setSummary(R.string.network_cdma_no_evdo);
                 break;
             case Phone.NT_MODE_TDSCDMA_ONLY:
                 mButtonEnabledNetworks.setValue(


### PR DESCRIPTION
technology
- 3G modes such as EV-DO, WCDMA etc are currently displayed as
  "3G" in mobile network settings. Some customers want to display
  the actual technology name instead of "3G".
- To maintain backward compatibility, the default strings for all
  3G technology are still "3G" (same for LTE and 2G), but the names
  can be overwritten in overlay files

Issue-id:RENDANG-176
Issue-id:SAMBAR-651

Change-Id: I2397a86b1d87dde62e1502aece6b72bb88e7b494
