### PR TITLE
PhoneToggler: persist nw mode change

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -126,6 +126,7 @@
     <uses-permission android:name="android.permission.CHANGE_COMPONENT_ENABLED_STATE" />
     <uses-permission android:name="android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST" />
     <uses-permission android:name="cyanogenmod.permission.HARDWARE_ABSTRACTION_ACCESS" />
+    <uses-permission android:name="com.android.phone.CHANGE_NETWORK_MODE" />
 
     <!-- This tells the activity manager to not delay any of our activity
          start requests, even if they happen immediately after the user

--- a/src/com/android/phone/PhoneToggler.java
+++ b/src/com/android/phone/PhoneToggler.java
@@ -19,16 +19,13 @@ package com.android.phone;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.os.AsyncResult;
-import android.os.Handler;
-import android.os.Message;
-import android.provider.Settings;
 import android.telephony.SubscriptionManager;
 import android.util.Log;
 
 import com.android.internal.telephony.Phone;
 import com.android.internal.telephony.PhoneConstants;
 import com.android.internal.telephony.PhoneFactory;
+import com.android.internal.telephony.SubscriptionController;
 
 public class PhoneToggler extends BroadcastReceiver  {
 
@@ -69,7 +66,8 @@ public class PhoneToggler extends BroadcastReceiver  {
                             || networkMode == Phone.NT_MODE_GSM_UMTS
                             || networkMode == Phone.NT_MODE_WCDMA_PREF
                             || networkMode == Phone.NT_MODE_LTE_GSM_WCDMA
-                            || networkMode == Phone.NT_MODE_WCDMA_ONLY) {
+                            || networkMode == Phone.NT_MODE_WCDMA_ONLY
+                            || networkMode == Phone.NT_MODE_LTE_ONLY) {
                         networkModeOk = true;
                     }
                 } else if (phoneType == PhoneConstants.PHONE_TYPE_CDMA) {
@@ -100,6 +98,8 @@ public class PhoneToggler extends BroadcastReceiver  {
     }
 
     private void changeNetworkMode(int modemNetworkMode) {
+        SubscriptionController.getInstance().setUserNwMode(
+                SubscriptionManager.getDefaultDataSubId(), modemNetworkMode);
         getPhone().setPreferredNetworkType(modemNetworkMode, null);
     }
 


### PR DESCRIPTION
Also allow the LTE_ONLY mode which is an option the user can choose.

Ref: CYNGNOS-1824

Change-Id: Ib6e5656e81b2f88aa597c30ba71e6f4c098bd27d
Signed-off-by: Roman Birg roman@cyngn.com
