### PR TITLE
Fix "Fix "multi-sim: fallback on active subId on emergency calls""

### DIFF
--- a/src/com/android/services/telephony/TelephonyConnectionService.java
+++ b/src/com/android/services/telephony/TelephonyConnectionService.java
@@ -645,7 +645,7 @@ public class TelephonyConnectionService extends ConnectionService {
             } catch (NullPointerException ex) {
                 Log.e(this, ex, "Exception : " + ex);
             }
-            return PhoneFactory.getPhone(phoneId);
+            return PhoneFactory.getDefaultPhone();
         }
 
         int subId = PhoneUtils.getSubIdForPhoneAccountHandle(accountHandle);


### PR DESCRIPTION
There's no phoneId without extphone. Go back to the original implementation
of resorting to the defaultphone.

Change-Id: I2b300d27f84be3489005f9630ed5cc0ec7c34599
