### PR TITLE
Telephony: add external network selection activity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -732,6 +732,16 @@
               <data android:scheme="package"/>
           </intent-filter>
        </receiver>
+
+        <activity android:name=".NetworkModePickerActivity"
+                  android:theme="@*android:style/Theme.DeviceDefault.Light.Dialog"
+                  android:permission="com.android.phone.CHANGE_NETWORK_MODE"
+                  android:excludeFromRecents="true">
+            <intent-filter>
+                <action android:name="cyanogenmod.platform.intent.action.NETWORK_MODE_PICKER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
     </application>
 
     <permission android:name="com.android.phone.CHANGE_NETWORK_MODE"

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -233,4 +233,8 @@
     <!-- Mobile network settings, COLP -->
     <string name="connected_line_identification_title">Connected line identification</string>
     <string name="connected_line_identification_summary">Disable this option if the numbers of the recipients don\'t show up in the call history</string>
+
+    <!-- Network mode picker dialog title -->
+    <string name="choose_network_mode_title">Choose network mode</string>
+    <string name="choose_network_mode_system_default">System default</string>
 </resources>

--- a/src/com/android/phone/MobileNetworkSettings.java
+++ b/src/com/android/phone/MobileNetworkSettings.java
@@ -507,15 +507,7 @@ public class MobileNetworkSettings extends PreferenceActivity
         mButton4glte = (SwitchPreference)findPreference(BUTTON_4G_LTE_KEY);
         mButton4glte.setOnPreferenceChangeListener(this);
 
-        try {
-            Context con = createPackageContext("com.android.systemui", 0);
-            int id = con.getResources().getIdentifier("config_show4GForLTE",
-                    "bool", "com.android.systemui");
-            mShow4GForLTE = con.getResources().getBoolean(id);
-        } catch (NameNotFoundException e) {
-            loge("NameNotFoundException for show4GFotLTE");
-            mShow4GForLTE = false;
-        }
+        mShow4GForLTE = show4GForLTE(this);
 
         //get UI object references
         PreferenceScreen prefSet = getPreferenceScreen();
@@ -641,8 +633,7 @@ public class MobileNetworkSettings extends PreferenceActivity
 
         PersistableBundle carrierConfig =
                 PhoneGlobals.getInstance().getCarrierConfigForSubId(mPhone.getSubId());
-        mIsGlobalCdma = isLteOnCdma
-                && carrierConfig.getBoolean(CarrierConfigManager.KEY_SHOW_CDMA_CHOICES_BOOL);
+        mIsGlobalCdma = isGlobalCDMA(phoneSubId, isLteOnCdma);
         if (carrierConfig.getBoolean(CarrierConfigManager.KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL)) {
             prefSet.removePreference(mButtonPreferredNetworkMode);
             prefSet.removePreference(mButtonEnabledNetworks);
@@ -681,45 +672,6 @@ public class MobileNetworkSettings extends PreferenceActivity
             prefSet.removePreference(mButtonPreferredNetworkMode);
             final int phoneType = mPhone.getPhoneType();
             if (phoneType == PhoneConstants.PHONE_TYPE_CDMA) {
-                int lteForced = android.provider.Settings.Global.getInt(
-                        mPhone.getContext().getContentResolver(),
-                        android.provider.Settings.Global.LTE_SERVICE_FORCED + mPhone.getSubId(),
-                        0);
-
-                if (isLteOnCdma) {
-                    if (lteForced == 0) {
-                        mButtonEnabledNetworks.setEntries(
-                                R.array.enabled_networks_cdma_choices);
-                        mButtonEnabledNetworks.setEntryValues(
-                                R.array.enabled_networks_cdma_values);
-                    } else {
-                        switch (settingsNetworkMode) {
-                            case Phone.NT_MODE_CDMA:
-                            case Phone.NT_MODE_CDMA_NO_EVDO:
-                            case Phone.NT_MODE_EVDO_NO_CDMA:
-                                mButtonEnabledNetworks.setEntries(
-                                        R.array.enabled_networks_cdma_no_lte_choices);
-                                mButtonEnabledNetworks.setEntryValues(
-                                        R.array.enabled_networks_cdma_no_lte_values);
-                                break;
-                            case Phone.NT_MODE_GLOBAL:
-                            case Phone.NT_MODE_LTE_CDMA_AND_EVDO:
-                            case Phone.NT_MODE_LTE_CDMA_EVDO_GSM_WCDMA:
-                            case Phone.NT_MODE_LTE_ONLY:
-                                mButtonEnabledNetworks.setEntries(
-                                        R.array.enabled_networks_cdma_only_lte_choices);
-                                mButtonEnabledNetworks.setEntryValues(
-                                        R.array.enabled_networks_cdma_only_lte_values);
-                                break;
-                            default:
-                                mButtonEnabledNetworks.setEntries(
-                                        R.array.enabled_networks_cdma_choices);
-                                mButtonEnabledNetworks.setEntryValues(
-                                        R.array.enabled_networks_cdma_values);
-                                break;
-                        }
-                    }
-                }
                 mCdmaOptions = new CdmaOptions(this, prefSet, mPhone);
 
                 // In World mode force a refresh of GSM Options.
@@ -727,54 +679,18 @@ public class MobileNetworkSettings extends PreferenceActivity
                     mGsmUmtsOptions = null;
                 }
             } else if (phoneType == PhoneConstants.PHONE_TYPE_GSM) {
-                if (isSupportTdscdma()) {
-                    mButtonEnabledNetworks.setEntries(
-                            R.array.enabled_networks_tdscdma_choices);
-                    mButtonEnabledNetworks.setEntryValues(
-                            R.array.enabled_networks_tdscdma_values);
-                } else if (!carrierConfig.getBoolean(CarrierConfigManager.KEY_PREFER_2G_BOOL)
-                        && !getResources().getBoolean(R.bool.config_enabled_lte)) {
-                    mButtonEnabledNetworks.setEntries(
-                            R.array.enabled_networks_except_gsm_lte_choices);
-                    mButtonEnabledNetworks.setEntryValues(
-                            R.array.enabled_networks_except_gsm_lte_values);
-                } else if (!carrierConfig.getBoolean(CarrierConfigManager.KEY_PREFER_2G_BOOL)) {
-                    int select = (mShow4GForLTE == true) ?
-                            R.array.enabled_networks_except_gsm_4g_choices
-                            : R.array.enabled_networks_except_gsm_choices;
-                    mButtonEnabledNetworks.setEntries(select);
-                    mButtonEnabledNetworks.setEntryValues(
-                            R.array.enabled_networks_except_gsm_values);
-                } else if (!getResources().getBoolean(R.bool.config_enabled_lte)) {
-                    mButtonEnabledNetworks.setEntries(
-                            R.array.enabled_networks_except_lte_choices);
-                    mButtonEnabledNetworks.setEntryValues(
-                            R.array.enabled_networks_except_lte_values);
-                } else if (mIsGlobalCdma) {
-                    mButtonEnabledNetworks.setEntries(
-                            R.array.enabled_networks_cdma_choices);
-                    mButtonEnabledNetworks.setEntryValues(
-                            R.array.enabled_networks_cdma_values);
-                } else {
-                    int select = (mShow4GForLTE == true) ? R.array.enabled_networks_4g_choices
-                            : R.array.enabled_networks_choices;
-                    mButtonEnabledNetworks.setEntries(select);
-                    mButtonEnabledNetworks.setEntryValues(
-                            R.array.enabled_networks_values);
-                }
                 mGsmUmtsOptions = new GsmUmtsOptions(this, prefSet, phoneSubId);
             } else {
                 throw new IllegalStateException("Unexpected phone type: " + phoneType);
             }
-            if (isWorldMode()) {
-                mButtonEnabledNetworks.setEntries(
-                        R.array.preferred_network_mode_choices_world_mode);
-                mButtonEnabledNetworks.setEntryValues(
-                        R.array.preferred_network_mode_values_world_mode);
-            }
+
+            int[] ev = getDeviceNetworkEntriesAndValues(this, mPhone.getSubId(), settingsNetworkMode);
+            mButtonEnabledNetworks.setEntries(ev[0]);
+            mButtonEnabledNetworks.setEntryValues(ev[1]);
             mButtonEnabledNetworks.setOnPreferenceChangeListener(this);
             if (DBG) log("settingsNetworkMode: " + settingsNetworkMode);
         }
+
 
         final boolean missingDataServiceUrl = TextUtils.isEmpty(
                 android.provider.Settings.Global.getString(getContentResolver(),
@@ -1379,27 +1295,7 @@ public class MobileNetworkSettings extends PreferenceActivity
     }
 
     private boolean isWorldMode() {
-        boolean worldModeOn = false;
-        final TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
-        final String configString = getResources().getString(R.string.config_world_mode);
-
-        if (!TextUtils.isEmpty(configString)) {
-            String[] configArray = configString.split(";");
-            // Check if we have World mode configuration set to True only or config is set to True
-            // and SIM GID value is also set and matches to the current SIM GID.
-            if (configArray != null &&
-                   ((configArray.length == 1 && configArray[0].equalsIgnoreCase("true")) ||
-                       (configArray.length == 2 && !TextUtils.isEmpty(configArray[1]) &&
-                           tm != null && configArray[1].equalsIgnoreCase(tm.getGroupIdLevel1())))) {
-                               worldModeOn = true;
-            }
-        }
-
-        if (DBG) {
-            log("isWorldMode=" + worldModeOn);
-        }
-
-        return worldModeOn;
+        return isWorldMode(this);
     }
 
     private void controlGsmOptions(boolean enable) {
@@ -1449,12 +1345,42 @@ public class MobileNetworkSettings extends PreferenceActivity
     }
 
     private boolean isSupportTdscdma() {
-        if (getResources().getBoolean(R.bool.config_support_tdscdma)) {
+        return isSupportTdscdma(this, mPhone.getSubId());
+    }
+
+    private static boolean isWorldMode(Context context) {
+        boolean worldModeOn = false;
+        final TelephonyManager tm = (TelephonyManager)
+                context.getSystemService(Context.TELEPHONY_SERVICE);
+        final String configString = context.getResources().getString(R.string.config_world_mode);
+
+        if (!TextUtils.isEmpty(configString)) {
+            String[] configArray = configString.split(";");
+            // Check if we have World mode configuration set to True only or config is set to True
+            // and SIM GID value is also set and matches to the current SIM GID.
+            if (configArray != null &&
+                    ((configArray.length == 1 && configArray[0].equalsIgnoreCase("true")) ||
+                            (configArray.length == 2 && !TextUtils.isEmpty(configArray[1]) &&
+                                    tm != null && configArray[1].equalsIgnoreCase(tm.getGroupIdLevel1())))) {
+                worldModeOn = true;
+            }
+        }
+
+        if (DBG) {
+            log("isWorldMode=" + worldModeOn);
+        }
+
+        return worldModeOn;
+    }
+
+    private static boolean isSupportTdscdma(Context context, int subId) {
+        if (context.getResources().getBoolean(R.bool.config_support_tdscdma)) {
             return true;
         }
 
-        String operatorNumeric = mPhone.getServiceState().getOperatorNumeric();
-        String[] numericArray = getResources().getStringArray(
+        final String operatorNumeric = TelephonyManager.from(context)
+                .getSimOperatorNumericForSubscription(subId);
+        String[] numericArray = context.getResources().getStringArray(
                 R.array.config_support_tdscdma_roaming_on_networks);
         if (numericArray.length == 0 || operatorNumeric == null) {
             return false;
@@ -1465,5 +1391,112 @@ public class MobileNetworkSettings extends PreferenceActivity
             }
         }
         return false;
+    }
+
+    private static boolean show4GForLTE(Context context) {
+        try {
+            Context con = context.createPackageContext("com.android.systemui", 0);
+            int id = con.getResources().getIdentifier("config_show4GForLTE",
+                    "bool", "com.android.systemui");
+            return con.getResources().getBoolean(id);
+        } catch (NameNotFoundException e) {
+            loge("NameNotFoundException for show4GFotLTE");
+            return false;
+        }
+    }
+
+    private static boolean isGlobalCDMA(int subId, boolean isLteOnCdma) {
+        PersistableBundle carrierConfig =
+                PhoneGlobals.getInstance().getCarrierConfigForSubId(subId);
+        return isLteOnCdma
+                && carrierConfig.getBoolean(CarrierConfigManager.KEY_SHOW_CDMA_CHOICES_BOOL);
+    }
+
+    /**
+     * Helper to retrieve the available network mode this device
+     *
+     * @return an int[] with resource arrays with a length 2 with the following
+     * <ul>
+     * <li>0 = entry choices</li>
+     * <li>1 = entry values</li>
+     * </ul>
+     */
+    public static int[] getDeviceNetworkEntriesAndValues(Context context, int subId,
+            int settingsNetworkMode) {
+
+        PersistableBundle carrierConfig =
+                PhoneGlobals.getInstance().getCarrierConfigForSubId(subId);
+
+        boolean isLteOnCdma = TelephonyManager.from(context).getLteOnCdmaMode(subId)
+                == PhoneConstants.LTE_ON_CDMA_TRUE;
+        final int phoneType = TelephonyManager.from(context).getCurrentPhoneType(subId);
+
+        int[] ev = new int[2];
+        if (phoneType == PhoneConstants.PHONE_TYPE_CDMA) {
+            int lteForced = android.provider.Settings.Global.getInt(
+                    context.getContentResolver(),
+                    android.provider.Settings.Global.LTE_SERVICE_FORCED + subId,
+                    0);
+
+            if (isLteOnCdma) {
+                if (lteForced == 0) {
+                    ev[0] = com.android.phone.R.array.enabled_networks_cdma_choices;
+                    ev[1] = com.android.phone.R.array.enabled_networks_cdma_values;
+                } else {
+                    switch (settingsNetworkMode) {
+                        case Phone.NT_MODE_CDMA:
+                        case Phone.NT_MODE_CDMA_NO_EVDO:
+                        case Phone.NT_MODE_EVDO_NO_CDMA:
+                            ev[0] = com.android.phone.R.array.enabled_networks_cdma_no_lte_choices;
+                            ev[1] = com.android.phone.R.array.enabled_networks_cdma_no_lte_values;
+                            break;
+                        case Phone.NT_MODE_GLOBAL:
+                        case Phone.NT_MODE_LTE_CDMA_AND_EVDO:
+                        case Phone.NT_MODE_LTE_CDMA_EVDO_GSM_WCDMA:
+                        case Phone.NT_MODE_LTE_ONLY:
+                            ev[0] = com.android.phone.R.array.enabled_networks_cdma_only_lte_choices;
+                            ev[1] = com.android.phone.R.array.enabled_networks_cdma_only_lte_values;
+                            break;
+                        default:
+                            ev[0] = com.android.phone.R.array.enabled_networks_cdma_choices;
+                            ev[1] = com.android.phone.R.array.enabled_networks_cdma_values;
+                            break;
+                    }
+                }
+            }
+        } else if (phoneType == PhoneConstants.PHONE_TYPE_GSM) {
+            if (isSupportTdscdma(context, subId)) {
+                ev[0] = com.android.phone.R.array.enabled_networks_tdscdma_choices;
+                ev[1] = com.android.phone.R.array.enabled_networks_tdscdma_values;
+            } else if (!carrierConfig.getBoolean(CarrierConfigManager.KEY_PREFER_2G_BOOL)
+                    && !context.getResources().getBoolean(com.android.phone.R.bool.config_enabled_lte)) {
+                ev[0] = com.android.phone.R.array.enabled_networks_except_gsm_lte_choices;
+                ev[1] = com.android.phone.R.array.enabled_networks_except_gsm_lte_values;
+            } else if (!carrierConfig.getBoolean(CarrierConfigManager.KEY_PREFER_2G_BOOL)) {
+                int select = (show4GForLTE(context)) ?
+                        com.android.phone.R.array.enabled_networks_except_gsm_4g_choices
+                        : com.android.phone.R.array.enabled_networks_except_gsm_choices;
+                ev[0] = select;
+                ev[1] = com.android.phone.R.array.enabled_networks_except_gsm_values;
+            } else if (!context.getResources().getBoolean(com.android.phone.R.bool.config_enabled_lte)) {
+                ev[0] = com.android.phone.R.array.enabled_networks_except_lte_choices;
+                ev[1] = com.android.phone.R.array.enabled_networks_except_lte_values;
+            } else if (isGlobalCDMA(subId, isLteOnCdma)) {
+                ev[0] = com.android.phone.R.array.enabled_networks_cdma_choices;
+                ev[1] = com.android.phone.R.array.enabled_networks_cdma_values;
+            } else {
+                int select = (show4GForLTE(context)) ? com.android.phone.R.array.enabled_networks_4g_choices
+                        : com.android.phone.R.array.enabled_networks_choices;
+                ev[0] = select;
+                ev[1] = com.android.phone.R.array.enabled_networks_values;
+            }
+        } else {
+            throw new IllegalStateException("Unexpected phone type: " + phoneType);
+        }
+        if (isWorldMode(context)) {
+            ev[0] = com.android.phone.R.array.preferred_network_mode_choices_world_mode;
+            ev[1] = com.android.phone.R.array.preferred_network_mode_values_world_mode;
+        }
+        return ev;
     }
 }

--- a/src/com/android/phone/NetworkModePickerActivity.java
+++ b/src/com/android/phone/NetworkModePickerActivity.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ * Copyright (C) 2013 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.phone;
+
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.PersistableBundle;
+import android.provider.Settings;
+import android.telephony.SubscriptionManager;
+import android.util.Log;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import com.android.internal.app.AlertActivity;
+import com.android.internal.app.AlertController;
+import com.android.internal.telephony.Phone;
+import com.android.internal.telephony.PhoneFactory;
+import com.android.internal.telephony.SubscriptionController;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+
+/**
+ * The {@link NetworkModePickerActivity} allows the user to choose a network mode
+ * and receive the result back.
+ *
+ * @hide
+ */
+public final class NetworkModePickerActivity extends AlertActivity implements
+        DialogInterface.OnClickListener, AlertController.AlertParams.OnPrepareListViewListener {
+
+    private static final String TAG = "NetworkModePicker";
+
+    private static final String SAVE_CLICKED_POS = "clicked_pos";
+
+    public static final String EXTRA_TITLE = "network_mode_picker::title";
+    public static final String EXTRA_NEUTRAL_TEXT = "network_mode_picker::neutral_text";
+    public static final String EXTRA_SHOW_NONE = "network_mode_picker::show_none";
+    public static final String EXTRA_SELECTED_MODE = "network_mode_picker::selected_mode";
+    public static final String EXTRA_SUBID = "network_mode_picker::sub_id";
+
+    public static final String EXTRA_NETWORK_MODE_PICKED = "network_mode_picker::chosen_value";
+
+
+    /** The position in the list of the last clicked item. */
+    private int mClickedPos = -1;
+
+    /** Whether this list has the 'None' item. */
+    private boolean mHasNoneItem;
+
+    private OnClickListener mDialogChoiceClickListener =
+            new OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            // Save the position of most recently clicked item
+            mClickedPos = which;
+        }
+
+    };
+
+    private String[] mNetworkChoices, mNetworkValues;
+    private int mInitialMode;
+    private int mSubId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+
+        if (savedInstanceState != null) {
+            mClickedPos = savedInstanceState.getInt(SAVE_CLICKED_POS, -1);
+        }
+
+        mSubId = intent.getIntExtra(EXTRA_SUBID, SubscriptionManager.INVALID_SUBSCRIPTION_ID);
+
+        if (mSubId == SubscriptionManager.INVALID_SUBSCRIPTION_ID) {
+            mSubId = SubscriptionManager.getDefaultDataSubId();
+        }
+
+        // Get whether to show the 'None' item
+        mHasNoneItem = intent.getBooleanExtra(EXTRA_SHOW_NONE, false);
+
+        mInitialMode = intent.getIntExtra(EXTRA_SELECTED_MODE,
+                mHasNoneItem ? -1 : getCurrentNetworkMode(mSubId));
+
+        Log.d(TAG, "mHasNoneItem: " + mHasNoneItem + ", mInitialMode: " + mInitialMode);
+
+        int[] ev = MobileNetworkSettings.getDeviceNetworkEntriesAndValues(this, mSubId,
+                mInitialMode);
+
+        mNetworkChoices = getResources().getStringArray(ev[0]);
+        mNetworkValues = getResources().getStringArray(ev[1]);
+
+        String noneItem = intent.getStringExtra(EXTRA_NEUTRAL_TEXT);
+        if (noneItem == null) {
+            Log.w(TAG, "caller requested a none item, but did not provide a none text!");
+            mHasNoneItem = false;
+        }
+
+        if (mHasNoneItem) {
+            ArrayList<String> choices = new ArrayList<String>();
+            ArrayList<String> values = new ArrayList<String>();
+
+            choices.add(noneItem);
+            values.add(String.valueOf(-1));
+
+            choices.addAll(Arrays.asList(mNetworkChoices));
+            values.addAll(Arrays.asList(mNetworkValues));
+
+            mNetworkChoices = new String[choices.size()];
+            mNetworkValues = new String[values.size()];
+
+            mNetworkChoices = choices.toArray(mNetworkChoices);
+            mNetworkValues = values.toArray(mNetworkValues);
+        }
+
+        final AlertController.AlertParams p = mAlertParams;
+        p.mAdapter = new ArrayAdapter<String>(this,
+                com.android.internal.R.layout.select_dialog_singlechoice_material, mNetworkChoices);
+        p.mOnClickListener = mDialogChoiceClickListener;
+        p.mIsSingleChoice = true;
+        p.mPositiveButtonText = getString(com.android.internal.R.string.ok);
+        p.mPositiveButtonListener = this;
+        p.mNegativeButtonText = getString(com.android.internal.R.string.cancel);
+        p.mPositiveButtonListener = this;
+        p.mOnPrepareListViewListener = this;
+
+        p.mTitle = intent.getCharSequenceExtra(EXTRA_TITLE);
+        if (p.mTitle == null) {
+            p.mTitle = getString(R.string.choose_network_mode_title);
+        }
+        setupAlert();
+    }
+
+    private int getCurrentNetworkMode(int subId) {
+        return SubscriptionController.getInstance().getUserNwMode(subId);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(SAVE_CLICKED_POS, mClickedPos);
+    }
+
+    @Override
+    public void onPrepareListView(ListView listView) {
+        mAlertParams.mCheckedItem = getIndexOfValue(String.valueOf(mInitialMode));
+    }
+
+    private int getIndexOfValue(String value) {
+        for (int i = 0; i < mNetworkValues.length; i++) {
+            String choice = mNetworkValues[i];
+            if (choice.equals(value)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /*
+     * On click of Ok/Cancel buttons
+     */
+    public void onClick(DialogInterface dialog, int which) {
+        boolean positiveResult = which == DialogInterface.BUTTON_POSITIVE;
+
+        if (positiveResult) {
+            Intent resultIntent = new Intent();
+
+            if (mClickedPos == -1) {
+                mClickedPos = getIndexOfValue(String.valueOf(mInitialMode));
+            }
+            resultIntent.putExtra(EXTRA_NETWORK_MODE_PICKED, mNetworkValues[mClickedPos]);
+            resultIntent.putExtra(EXTRA_SUBID, mSubId);
+
+            setResult(RESULT_OK, resultIntent);
+        } else {
+            setResult(RESULT_CANCELED);
+        }
+
+        finish();
+    }
+}

--- a/src/com/android/phone/PhoneToggler.java
+++ b/src/com/android/phone/PhoneToggler.java
@@ -23,11 +23,10 @@ import android.telephony.SubscriptionManager;
 import android.util.Log;
 
 import com.android.internal.telephony.Phone;
-import com.android.internal.telephony.PhoneConstants;
 import com.android.internal.telephony.PhoneFactory;
 import com.android.internal.telephony.SubscriptionController;
 
-public class PhoneToggler extends BroadcastReceiver  {
+public class PhoneToggler extends BroadcastReceiver {
 
     @Deprecated
     public static final String ACTION_REQUEST_NETWORK_MODE =
@@ -38,16 +37,10 @@ public class PhoneToggler extends BroadcastReceiver  {
 
     public static final String EXTRA_NETWORK_MODE = "networkMode";
 
-    public static final String CHANGE_NETWORK_MODE_PERM =
-            "com.android.phone.CHANGE_NETWORK_MODE";
+    public static final String EXTRA_SUB_ID = "subId";
 
     private static final String LOG_TAG = "PhoneToggler";
     private static final boolean DBG = false;
-
-    private Phone getPhone() {
-        return PhoneFactory.getPhone(SubscriptionManager.getPhoneId(
-                SubscriptionManager.getDefaultDataSubId()));
-    }
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -55,52 +48,73 @@ public class PhoneToggler extends BroadcastReceiver  {
         if (ACTION_MODIFY_NETWORK_MODE.equals(action)) {
             if (DBG) Log.d(LOG_TAG, "Got modify intent");
             if (intent.getExtras() != null) {
-                int networkMode = intent.getExtras().getInt(EXTRA_NETWORK_MODE);
-                boolean networkModeOk = false;
-                Phone phone = getPhone();
-                int phoneType = phone.getPhoneType();
-                boolean isLteOnCdma = phone.getLteOnCdmaMode() == PhoneConstants.LTE_ON_CDMA_TRUE;
+                SubscriptionController subCtrl = SubscriptionController.getInstance();
 
-                if (phoneType == PhoneConstants.PHONE_TYPE_GSM) {
-                    if (networkMode == Phone.NT_MODE_GSM_ONLY
-                            || networkMode == Phone.NT_MODE_GSM_UMTS
-                            || networkMode == Phone.NT_MODE_WCDMA_PREF
-                            || networkMode == Phone.NT_MODE_LTE_GSM_WCDMA
-                            || networkMode == Phone.NT_MODE_WCDMA_ONLY
-                            || networkMode == Phone.NT_MODE_LTE_ONLY) {
-                        networkModeOk = true;
-                    }
-                } else if (phoneType == PhoneConstants.PHONE_TYPE_CDMA) {
-                    if (networkMode == Phone.NT_MODE_CDMA
-                            || networkMode == Phone.NT_MODE_CDMA_NO_EVDO
-                            || networkMode == Phone.NT_MODE_EVDO_NO_CDMA) {
-                        networkModeOk = true;
-                    }
-                }
-                if (context.getResources().getBoolean(R.bool.world_phone) || isLteOnCdma) {
-                    if (networkMode == Phone.NT_MODE_GLOBAL) {
-                        networkModeOk = true;
-                    }
-                }
+                int networkMode = intent.getExtras().getInt(EXTRA_NETWORK_MODE, -1);
+                int subId = intent.getExtras().getInt(EXTRA_SUB_ID,
+                        SubscriptionManager.getDefaultDataSubId());
 
-                if (networkModeOk) {
+                // since the caller must be a system app, it's assumed that they have already
+                // chosen a valid network mode for this subId, so only basic validation is done
+                if (isValidModemNetworkMode(networkMode)) {
                     if (DBG) Log.d(LOG_TAG, "Changing network mode to " + networkMode);
-                    changeNetworkMode(networkMode);
+                    subCtrl.setUserNwMode(subId, networkMode);
+                    try {
+                        PhoneFactory.getPhone(SubscriptionManager.getPhoneId(subId))
+                                .setPreferredNetworkType(networkMode, null);
+                    } catch (Throwable t) {
+                        Log.d(LOG_TAG, "error setting preferred network", t);
+                    }
                 } else {
-                    Log.e(LOG_TAG,"Invalid network mode: "+networkMode);
+                    if (DBG) {
+                        String error = "invalid network mode (%d) or invalid subId (%d)";
+                        Log.d(LOG_TAG, String.format(error, networkMode, subId));
+                    }
                 }
             }
         } else if (ACTION_REQUEST_NETWORK_MODE.equals(action)) {
-            if (DBG) Log.e(LOG_TAG,"Requested network mode. Not honoring request. Get your own info.");
+            if (DBG) {
+                Log.e(LOG_TAG, "Requested network mode. Not honoring request. Get your own info.");
+            }
         } else {
-            if (DBG) Log.d(LOG_TAG,"Unexpected intent: " + intent);
+            if (DBG) {
+                Log.d(LOG_TAG, "Unexpected intent: " + intent);
+            }
         }
     }
 
-    private void changeNetworkMode(int modemNetworkMode) {
-        SubscriptionController.getInstance().setUserNwMode(
-                SubscriptionManager.getDefaultDataSubId(), modemNetworkMode);
-        getPhone().setPreferredNetworkType(modemNetworkMode, null);
+    /*
+     * Basic validation; from MobileNetworkSettings
+     */
+    private static boolean isValidModemNetworkMode(int mode) {
+        switch (mode) {
+            case Phone.NT_MODE_WCDMA_PREF:
+            case Phone.NT_MODE_GSM_ONLY:
+            case Phone.NT_MODE_WCDMA_ONLY:
+            case Phone.NT_MODE_GSM_UMTS:
+            case Phone.NT_MODE_CDMA:
+            case Phone.NT_MODE_CDMA_NO_EVDO:
+            case Phone.NT_MODE_EVDO_NO_CDMA:
+            case Phone.NT_MODE_GLOBAL:
+            case Phone.NT_MODE_LTE_CDMA_AND_EVDO:
+            case Phone.NT_MODE_LTE_GSM_WCDMA:
+            case Phone.NT_MODE_LTE_CDMA_EVDO_GSM_WCDMA:
+            case Phone.NT_MODE_LTE_ONLY:
+            case Phone.NT_MODE_LTE_WCDMA:
+            case Phone.NT_MODE_TDSCDMA_ONLY:
+            case Phone.NT_MODE_TDSCDMA_WCDMA:
+            case Phone.NT_MODE_LTE_TDSCDMA:
+            case Phone.NT_MODE_TDSCDMA_GSM:
+            case Phone.NT_MODE_LTE_TDSCDMA_GSM:
+            case Phone.NT_MODE_TDSCDMA_GSM_WCDMA:
+            case Phone.NT_MODE_LTE_TDSCDMA_WCDMA:
+            case Phone.NT_MODE_LTE_TDSCDMA_GSM_WCDMA:
+            case Phone.NT_MODE_TDSCDMA_CDMA_EVDO_GSM_WCDMA:
+            case Phone.NT_MODE_LTE_TDSCDMA_CDMA_EVDO_GSM_WCDMA:
+                return true;
+            default:
+                return false;
+        }
     }
 
 }


### PR DESCRIPTION
Instead of trying to recreate the logic inside the profile
configuration, allow the profile setup to ask for these and return the
result.

Ref: CYNGNOS-1463

Change-Id: I30d46b475a1bf11bd3360059c00c3b6602fc3759
Signed-off-by: Roman Birg roman@cyngn.com
